### PR TITLE
Fix es6 incorrect description and test

### DIFF
--- a/curriculum/challenges/02-javascript-algorithms-and-data-structures/es6.json
+++ b/curriculum/challenges/02-javascript-algorithms-and-data-structures/es6.json
@@ -896,7 +896,7 @@
         "<blockquote>const person = {<br>&nbsp;&nbsp;name: \"Zodiac Hasbro\",<br>&nbsp;&nbsp;age: 56<br>};<br><br>// string interpolation<br>const greeting = `Hello, my name is ${person.name}!<br>I am ${person.age} years old.`;<br><br>console.log(greeting); // 打印出<br>// Hello, my name is Zodiac Hasbro!<br>// I am 56 years old.<br></blockquote>",
         "这段代码有许多的不同：",
         "首先，上面使用的 <code>${variable}</cpode> 语法是一个占位符。这样一来，你将不再需要使用<code>+</code>运算符来连接字符串。当需要在字符串里增加变量的时候，你只需要在变量的外面括上<code>${</code>和<code>}</code>，并将其放在字符串里就可以了。",
-        "其次，在例子使用了反引号（<code>`</code），而不是引号（<code>`</code>或者<code>\"</code>）将字符串括了起来，并且这个字符串可以换行。",
+        "其次，在例子使用了反引号（<code>`</code），而不是引号（<code>'</code>或者<code>\"</code>）将字符串括了起来，并且这个字符串可以换行。",
         "这个新的方式使你可以更灵活的创建复杂的字符串。",
         "<hr>",
         "使用模板字符串的反引号的语法来展示<code>result</code>对象的<code>failure</code>数组内的每个条目。每个条目应该括在带有<code>text-warning</code>类属性的<code>li</code>标签中，并赋值给<code>resultDisplayArray</code>。"
@@ -911,8 +911,8 @@
           "testString": "assert(makeList(result.failure).every((v, i) => v === `<li class=\"text-warning\">${result.failure[i]}</li>`), '<code>resultDisplayArray</code> 要有正确的输出。');"
         },
         {
-          "text": "使用了模板字符串。",
-          "testString": "getUserInput => assert(getUserInput('index').match(/`<li \\s*class\\s*=\\s*(\"\\s*text-warning\\s*\"|'\\s*text-warning\\s*')\\s*>\\s*\\$\\s*\\{(\\s*\\w+\\s*|\\s*\\w+\\s*\\[\\s*[\\w]+\\s*\\]\\s*)\\}\\s*<\\s*\\/li\\s*>`/g), '使用了模板字符串。');"
+          "text": "应使用模板字符串。",
+          "testString": "getUserInput => assert(getUserInput('index').match(/`.*`/g), '应使用模板字符串。');"
         }
       ],
       "releasedOn": "Feb 17, 2017",


### PR DESCRIPTION
Challenge: https://learn.freecodecamp.one/javascript-algorithms-and-data-structures/es6/create-strings-using-template-literals

Reference: https://github.com/freeCodeCamp/curriculum/blob/dev/challenges/02-javascript-algorithms-and-data-structures/es6.json#L1012

Fix that the following code won't pass:
```
const resultDisplayArray = [
  `<li class="text-warning">no-var</li>`,
  `<li class="text-warning">var-on-top</li>`,
  `<li class="text-warning">linebreak</li>`
];
```